### PR TITLE
fix fp construct name length bug

### DIFF
--- a/src/demo/fleet-provision/greengrass-v2-mode/deploy.ts
+++ b/src/demo/fleet-provision/greengrass-v2-mode/deploy.ts
@@ -4,7 +4,7 @@ import * as cdk from '@aws-cdk/core';
 import { FleetProvision } from '../../..';
 
 const app = new cdk.App();
-const id = 'FleetProvisionDemo' + Date.now();
+const id = 'FleetProvisionDemo';
 const stack = new cdk.Stack(app, id);
 const vault = new s3.Bucket(stack, 'myVault');
 const fleetProvision = new FleetProvision(stack, id, {

--- a/src/demo/fleet-provision/regular-mode/deploy.ts
+++ b/src/demo/fleet-provision/regular-mode/deploy.ts
@@ -4,7 +4,7 @@ import * as cdk from '@aws-cdk/core';
 import { FleetProvision } from '../../..';
 
 const app = new cdk.App();
-const id = 'FleetProvisionDemo' + Date.now();
+const id = 'FleetProvisionDemo';
 const stack = new cdk.Stack(app, id);
 const vault = new s3.Bucket(stack, 'myVault');
 const fleetProvision = new FleetProvision(stack, id, {


### PR DESCRIPTION
Fixes #

Fleet-Provision construct name is too long in the demonstration file. Remove the time postfix.