### PR TITLE
fix: import from base aws-cdk-lib path

### DIFF
--- a/src/components/ca-registrator.ts
+++ b/src/components/ca-registrator.ts
@@ -1,4 +1,7 @@
 import {
+  Duration,
+} from 'aws-cdk-lib';
+import {
   PolicyStatement,
   Effect,
   Policy,
@@ -6,9 +9,6 @@ import {
 import {
   NodejsFunction,
 } from 'aws-cdk-lib/aws-lambda-nodejs';
-import {
-  Duration,
-} from 'aws-cdk-lib/core';
 import {
   Construct,
 } from 'constructs';

--- a/src/components/deivce-certificate-generator.ts
+++ b/src/components/deivce-certificate-generator.ts
@@ -1,4 +1,7 @@
 import {
+  Duration,
+} from 'aws-cdk-lib';
+import {
   PolicyStatement,
   Effect,
   Policy,
@@ -6,9 +9,6 @@ import {
 import {
   NodejsFunction,
 } from 'aws-cdk-lib/aws-lambda-nodejs';
-import {
-  Duration,
-} from 'aws-cdk-lib/core';
 import {
   Construct,
 } from 'constructs';

--- a/src/demo/fleet-provision/greengrass-v2-mode/deploy.ts
+++ b/src/demo/fleet-provision/greengrass-v2-mode/deploy.ts
@@ -1,14 +1,14 @@
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   LambdaIntegration,
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   FleetProvision,
 } from '../../..';

--- a/src/demo/fleet-provision/regular-mode/deploy.ts
+++ b/src/demo/fleet-provision/regular-mode/deploy.ts
@@ -1,14 +1,14 @@
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   LambdaIntegration,
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   FleetProvision,
 } from '../../..';

--- a/src/demo/jitp/deploy.ts
+++ b/src/demo/jitp/deploy.ts
@@ -1,14 +1,14 @@
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   RestApi,
   LambdaIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   JustInTimeProvision,
 } from '../..';

--- a/src/demo/jitr/deploy.ts
+++ b/src/demo/jitr/deploy.ts
@@ -1,4 +1,8 @@
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   LambdaIntegration,
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
@@ -10,10 +14,6 @@ import {
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import { JustInTimeRegistration } from '../..';
 
 const app = new App();

--- a/test/construct/integ.export.test.ts
+++ b/test/construct/integ.export.test.ts
@@ -1,11 +1,11 @@
 import * as path from 'path';
 import {
-  Bucket,
-} from 'aws-cdk-lib/aws-s3';
-import {
   App,
   Stack,
-} from 'aws-cdk-lib/core';
+} from 'aws-cdk-lib';
+import {
+  Bucket,
+} from 'aws-cdk-lib/aws-s3';
 import {
   CaRegistrator,
   DeviceActivator,

--- a/test/construct/integ.fleet-provision.test.ts
+++ b/test/construct/integ.fleet-provision.test.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   Template,
 } from 'aws-cdk-lib/assertions';
 import {
@@ -8,10 +12,6 @@ import {
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   FleetProvision,
 } from '../../src';

--- a/test/construct/integ.just-in-time-provision.test.ts
+++ b/test/construct/integ.just-in-time-provision.test.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   Template,
 } from 'aws-cdk-lib/assertions';
 import {
@@ -8,10 +12,6 @@ import {
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   JustInTimeProvision,
 } from '../../src';

--- a/test/construct/integ.just-in-time-registration.test.ts
+++ b/test/construct/integ.just-in-time-registration.test.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 import {
+  App,
+  Stack,
+} from 'aws-cdk-lib';
+import {
   Template,
 } from 'aws-cdk-lib/assertions';
 import {
@@ -10,10 +14,6 @@ import {
 import {
   Bucket,
 } from 'aws-cdk-lib/aws-s3';
-import {
-  App,
-  Stack,
-} from 'aws-cdk-lib/core';
 import {
   JustInTimeRegistration,
 } from '../../src';


### PR DESCRIPTION
See https://github.com/aws/aws-cdk/issues/17950 for more information on
this issue.